### PR TITLE
Fix nlist method

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -263,6 +263,11 @@ class FtpClient implements Countable
 
         $files = $this->ftp->nlist($directory);
 
+        foreach ($files as $k => $file) {
+            $pieces = explode(DIRECTORY_SEPARATOR, $file);
+            $files[$k] = end($pieces);
+        }
+
         if ($files === false) {
             throw new FtpException('Unable to list directory');
         }

--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -263,13 +263,13 @@ class FtpClient implements Countable
 
         $files = $this->ftp->nlist($directory);
 
+        if ($files === false) {
+            throw new FtpException('Unable to list directory');
+        }
+
         foreach ($files as $k => $file) {
             $pieces = explode(DIRECTORY_SEPARATOR, $file);
             $files[$k] = end($pieces);
-        }
-
-        if ($files === false) {
-            throw new FtpException('Unable to list directory');
         }
 
         $result  = array();


### PR DESCRIPTION
PHP native method "nlist" returns list of full directories in current dir, but in method "FtpClient::nlist" expects only list of directories names, without full path