### PR TITLE
Unset the internal connection when closing a connection explicitly 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 .DS_Store
 Thumbs.db
 /.Trash-1000
+.idea/

--- a/src/FtpClient/FtpWrapper.php
+++ b/src/FtpClient/FtpWrapper.php
@@ -61,7 +61,7 @@ class FtpWrapper
     /**
      * Constructor.
      *
-     * @param ressource &$connection The FTP (or SSL-FTP) connection (takes by reference).
+     * @param resource &$connection The FTP (or SSL-FTP) connection (takes by reference).
      */
     public function __construct(&$connection)
     {


### PR DESCRIPTION
to avoid E_WARNING when destructor tries to close the connection again
Fixed some type hints in PHPDoc comments
Removed @method close() and @method rawList() in FtpClient
Removed unused "use \Closure"