### PR TITLE
putAll moving into directory when the directory exists.

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -594,7 +594,7 @@ class FtpClient implements Countable
                 // do the following if it is a directory
                 if (is_dir($source_directory.'/'.$file)) {
 
-                    if (!@$this->ftp->chdir($target_directory.'/'.$file)) {
+                    if (!$this->isDir($target_directory.'/'.$file)) {
 
                         // create directories that do not yet exist
                         $this->ftp->mkdir($target_directory.'/'.$file);


### PR DESCRIPTION
the putAll method was checking if a dir exists by using chdir, therefore when the dir existed it would move into this directory and then put all the files to be uploaded into this folder instead of overwriting the old ones. using the isDir method fixed this issue.