### PR TITLE
Skip mkdir if directory name is empty after explode parts

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -372,6 +372,8 @@ class FtpClient implements Countable
 
         foreach ($parts as $part) {
 
+            if($part == "") continue;
+
             if (!@$this->ftp->chdir($part)) {
                 $result = $this->ftp->mkdir($part);
                 $this->ftp->chdir($part);


### PR DESCRIPTION
When trying to create dirs recursively i.e. 
`/test/path`
 ftp_mkdir() return an error:
`ftp_mkdir(): Invalid number of arguments`
because explode parts is
`["","test","path"]`
obvious "" is not valid name for dir.

Thank you.