### PR TITLE
Fixes return type annotation: FTPClient -> FtpClient

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -144,7 +144,7 @@ class FtpClient implements Countable
      * @param int    $port
      * @param int    $timeout
      *
-     * @return FTPClient
+     * @return FtpClient
      * @throws FtpException If unable to connect
      */
     public function connect($host, $ssl = false, $port = 21, $timeout = 90)


### PR DESCRIPTION
I ran [Psalm](https://getpsalm.org) earlier on a project I'm working on that depends on this package and got the following error:

```
Scanning files...
Analyzing files...

ERROR: InvalidClass - src/Ftp/Adapter/Ftp.php:23:13 - Class or interface FtpClient\FTPClient has wrong casing
            $this->connect($hostname, $ssl, $port, $timeout);


------------------------------
1 errors found
------------------------------
```

This was because the hinted return type of `FtpClient\FtpClient::connect()` is `FTPClient`, when it should be `FtpClient`.