### PR TITLE
Require ext-ftp in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     }
   ],
   "require": {
-    "php": ">=5.4"
+    "php": ">=5.4",
+    "ext-ftp": "*"
   },
   "autoload": {
     "psr-0": {"FtpClient": "src/"}


### PR DESCRIPTION
This library cannot work without the `ftp` extension, so it should be listed in the required dependencies in composer.json.