### PR TITLE
Always mute warnings

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -150,9 +150,9 @@ class FtpClient implements Countable
     public function connect($host, $ssl = false, $port = 21, $timeout = 90)
     {
         if ($ssl) {
-            $this->conn = @$this->ftp->ssl_connect($host, $port, $timeout);
+            $this->conn = $this->ftp->ssl_connect($host, $port, $timeout);
         } else {
-            $this->conn = @$this->ftp->connect($host, $port, $timeout);
+            $this->conn = $this->ftp->connect($host, $port, $timeout);
         }
 
         if (!$this->conn) {
@@ -243,7 +243,7 @@ class FtpClient implements Countable
      */
     public function up()
     {
-        $result = @$this->ftp->cdup();
+        $result = $this->ftp->cdup();
 
         if ($result === false) {
             throw new FtpException('Unable to get parent folder');
@@ -374,7 +374,7 @@ class FtpClient implements Countable
                 continue;
             }
 
-            if (!@$this->ftp->chdir($part)) {
+            if (!$this->ftp->chdir($part)) {
                 $result = $this->ftp->mkdir($part);
                 $this->ftp->chdir($part);
             }
@@ -449,8 +449,8 @@ class FtpClient implements Countable
     public function remove($path, $recursive = false)
     {
         try {
-            if (@$this->ftp->delete($path)
-            or ($this->isDir($path) and @$this->rmdir($path, $recursive))) {
+            if ($this->ftp->delete($path)
+            or ($this->isDir($path) and $this->rmdir($path, $recursive))) {
                 return true;
             }
 
@@ -475,7 +475,7 @@ class FtpClient implements Countable
             throw new FtpException('Unable to resolve the current directory');
         }
 
-        if (@$this->ftp->chdir($directory)) {
+        if ($this->ftp->chdir($directory)) {
             $this->ftp->chdir($pwd);
             return true;
         }

--- a/src/FtpClient/FtpWrapper.php
+++ b/src/FtpClient/FtpWrapper.php
@@ -82,7 +82,7 @@ class FtpWrapper
 
         if (function_exists($function)) {
             array_unshift($arguments, $this->conn);
-            return call_user_func_array($function, $arguments);
+            return @call_user_func_array($function, $arguments);
         }
 
         throw new FtpException("{$function} is not a valid FTP function");
@@ -98,7 +98,7 @@ class FtpWrapper
      */
     public function connect($host, $port = 21, $timeout = 90)
     {
-        return ftp_connect($host, $port, $timeout);
+        return @ftp_connect($host, $port, $timeout);
     }
 
     /**
@@ -110,6 +110,6 @@ class FtpWrapper
      */
     public function ssl_connect($host, $port = 21, $timeout = 90)
     {
-        return ftp_ssl_connect($host, $port, $timeout);
+        return @ftp_ssl_connect($host, $port, $timeout);
     }
 }


### PR DESCRIPTION
Most `ftp_*` functions trigger a warning, in addition to returning `false`, when an error occurs.

Some of the methods in this library [use the mute operator `@`](https://github.com/Nicolab/php-ftp-client/blob/456a7f7a681128d9a7ebaed2f831dc9b2140b5ab/src/FtpClient/FtpClient.php#L246), while [others do not](https://github.com/Nicolab/php-ftp-client/blob/456a7f7a681128d9a7ebaed2f831dc9b2140b5ab/src/FtpClient/FtpClient.php#L209), for no apparent reason.

For example, attempting to `login()` with an invalid username/password currently triggers a PHP warning.

This PR proposes to mute warnings in all FTP operations, in a centralized place, the lower level `FtpWrapper`. `FtpClient` can now safely assume that no warning will be thrown, and stop using silence operators.