### PR TITLE
fix recursive loop when deleting folders

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -401,6 +401,12 @@ class FtpClient implements Countable
 
             // remove children
             foreach ($files as $file) {
+                // skip removing if "file" is pseudo directory like . or ..
+                $items = explode('/', $file);
+                if (in_array(end($items), ['.', '..'])) {
+                    continue;
+                }
+
                 $this->remove($file, true);
             }
         }

--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -401,12 +401,6 @@ class FtpClient implements Countable
 
             // remove children
             foreach ($files as $file) {
-                // skip removing if "file" is pseudo directory like . or ..
-                $items = explode('/', $file);
-                if (in_array(end($items), ['.', '..'])) {
-                    continue;
-                }
-
                 $this->remove($file, true);
             }
         }
@@ -451,6 +445,10 @@ class FtpClient implements Countable
      */
     public function remove($path, $recursive = false)
     {
+        if ($path == '.' || $path == '..') {
+            return false;
+        }
+
         try {
             if (@$this->ftp->delete($path)
             or ($this->isDir($path) and $this->rmdir($path, $recursive))) {


### PR DESCRIPTION
When removing items from folder it also tries to remove pseudo files like "." or "..". Doing so cause infinite loop when traversing through folders