### PR TITLE
Suggest brick/ftp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+*Note: this package will not receive new features, and may only receive bug fixes from now on. If you're looking for an actively maintained alternative, you may want to check out [brick/ftp](https://github.com/brick/ftp).*
+
 # nicolab/php-ftp-client
 
 A flexible FTP and SSL-FTP client for PHP.


### PR DESCRIPTION
Hi!

Following your [comment](https://github.com/Nicolab/php-ftp-client/pull/42#issuecomment-482692265) in another thread, earlier this year:

> For the issues, I had several issues every week to use CURL instead FTP, to do otherwise, to rename functions, to support SSH... Sometimes rusty limit, so I disabled the issue because this lib is meant to stay simple and will not evolve.

I've started working on a new FTP client: https://github.com/brick/ftp

I started this project because I need to guarantee that *any* unexpected error will throw an exception, and that no PHP warning will ever be triggered.

It's nowhere as feature complete as your library right now, but I'm planning to actively maintain it in the near future, so I will quickly respond to feature requests, if any.

As such, **would you be OK to leave a note in the README to direct users to `brick/ftp`**, if they need a maintained library with a potential for new features?

This would read:

> Note: this package will not receive new features, and may only receive bug fixes. If you're looking for an actively maintained alternative, you may want to check out [brick/ftp](https://github.com/brick/ftp).

You're welcome to adapt the text, obviously. And if you don't want to leave a note in the README, I'll understand.

Thanks either way, for the time you invested in this library! 👍 