### PR TITLE
fix incorrect @method annotations

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -41,7 +41,7 @@ use \Countable;
  * @method bool set_option(int $option, mixed $value) Set miscellaneous runtime FTP options
  * @method bool site(string $command) Sends a SITE command to the server
  * @method int size(string $remote_file) Returns the size of the given file
- * @method string systype() systype() Returns the system type identifier of the remote FTP server
+ * @method string systype() Returns the system type identifier of the remote FTP server
  *
  * @author Nicolas Tallefourtane <dev@nicolab.net>
  */

--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -16,31 +16,31 @@ use \Countable;
 /**
  * The FTP and SSL-FTP client for PHP.
  *
- * @method bool alloc() alloc(int $filesize, string &$result = null) Allocates space for a file to be uploaded
- * @method bool cdup() cdup() Changes to the parent directory
- * @method bool chdir() chdir(string $directory) Changes the current directory on a FTP server
- * @method int chmod() chmod(int $mode, string $filename) Set permissions on a file via FTP
- * @method bool delete() delete(string $path) Deletes a file on the FTP server
- * @method bool exec() exec(string $command) Requests execution of a command on the FTP server
- * @method bool fget() fget(resource $handle, string $remote_file, int $mode, int $resumepos = 0) Downloads a file from the FTP server and saves to an open file
- * @method bool fput() fput(string $remote_file, resource $handle, int $mode, int $startpos = 0) Uploads from an open file to the FTP server
- * @method mixed get_option() get_option(int $option) Retrieves various runtime behaviours of the current FTP stream
- * @method bool get() get(string $local_file, string $remote_file, int $mode, int $resumepos = 0) Downloads a file from the FTP server
- * @method int mdtm() mdtm(string $remote_file) Returns the last modified time of the given file
- * @method int nb_continue() nb_continue() Continues retrieving/sending a file (non-blocking)
- * @method int nb_fget() nb_fget(resource $handle, string $remote_file, int $mode, int $resumepos = 0) Retrieves a file from the FTP server and writes it to an open file (non-blocking)
- * @method int nb_fput() nb_fput(string $remote_file, resource $handle, int $mode, int $startpos = 0) Stores a file from an open file to the FTP server (non-blocking)
- * @method int nb_get() nb_get(string $local_file, string $remote_file, int $mode, int $resumepos = 0) Retrieves a file from the FTP server and writes it to a local file (non-blocking)
- * @method int nb_put() nb_put(string $remote_file, string $local_file, int $mode, int $startpos = 0) Stores a file on the FTP server (non-blocking)
- * @method bool pasv() pasv(bool $pasv) Turns passive mode on or off
- * @method bool put() put(string $remote_file, string $local_file, int $mode, int $startpos = 0) Uploads a file to the FTP server
- * @method string pwd() pwd() Returns the current directory name
- * @method bool quit() quit() Closes an FTP connection
- * @method array raw() raw(string $command) Sends an arbitrary command to an FTP server
- * @method bool rename() rename(string $oldname, string $newname) Renames a file or a directory on the FTP server
- * @method bool set_option() set_option(int $option, mixed $value) Set miscellaneous runtime FTP options
- * @method bool site() site(string $command) Sends a SITE command to the server
- * @method int size() size(string $remote_file) Returns the size of the given file
+ * @method bool alloc(int $filesize, string &$result = null) Allocates space for a file to be uploaded
+ * @method bool cdup() Changes to the parent directory
+ * @method bool chdir(string $directory) Changes the current directory on a FTP server
+ * @method int chmod(int $mode, string $filename) Set permissions on a file via FTP
+ * @method bool delete(string $path) Deletes a file on the FTP server
+ * @method bool exec(string $command) Requests execution of a command on the FTP server
+ * @method bool fget(resource $handle, string $remote_file, int $mode, int $resumepos = 0) Downloads a file from the FTP server and saves to an open file
+ * @method bool fput(string $remote_file, resource $handle, int $mode, int $startpos = 0) Uploads from an open file to the FTP server
+ * @method mixed get_option(int $option) Retrieves various runtime behaviours of the current FTP stream
+ * @method bool get(string $local_file, string $remote_file, int $mode, int $resumepos = 0) Downloads a file from the FTP server
+ * @method int mdtm(string $remote_file) Returns the last modified time of the given file
+ * @method int nb_continue() Continues retrieving/sending a file (non-blocking)
+ * @method int nb_fget(resource $handle, string $remote_file, int $mode, int $resumepos = 0) Retrieves a file from the FTP server and writes it to an open file (non-blocking)
+ * @method int nb_fput(string $remote_file, resource $handle, int $mode, int $startpos = 0) Stores a file from an open file to the FTP server (non-blocking)
+ * @method int nb_get(string $local_file, string $remote_file, int $mode, int $resumepos = 0) Retrieves a file from the FTP server and writes it to a local file (non-blocking)
+ * @method int nb_put(string $remote_file, string $local_file, int $mode, int $startpos = 0) Stores a file on the FTP server (non-blocking)
+ * @method bool pasv(bool $pasv) Turns passive mode on or off
+ * @method bool put(string $remote_file, string $local_file, int $mode, int $startpos = 0) Uploads a file to the FTP server
+ * @method string pwd() Returns the current directory name
+ * @method bool quit() Closes an FTP connection
+ * @method array raw(string $command) Sends an arbitrary command to an FTP server
+ * @method bool rename(string $oldname, string $newname) Renames a file or a directory on the FTP server
+ * @method bool set_option(int $option, mixed $value) Set miscellaneous runtime FTP options
+ * @method bool site(string $command) Sends a SITE command to the server
+ * @method int size(string $remote_file) Returns the size of the given file
  * @method string systype() systype() Returns the system type identifier of the remote FTP server
  *
  * @author Nicolas Tallefourtane <dev@nicolab.net>

--- a/src/FtpClient/FtpWrapper.php
+++ b/src/FtpClient/FtpWrapper.php
@@ -14,38 +14,38 @@ namespace FtpClient;
 /**
  * Wrap the PHP FTP functions
  *
- * @method bool alloc() alloc(int $filesize, string &$result = null) Allocates space for a file to be uploaded
- * @method bool cdup() cdup() Changes to the parent directory
- * @method bool chdir() chdir(string $directory) Changes the current directory on a FTP server
- * @method int chmod() chmod(int $mode, string $filename) Set permissions on a file via FTP
- * @method bool close() close() Closes an FTP connection
- * @method bool delete() delete(string $path) Deletes a file on the FTP server
- * @method bool exec() exec(string $command) Requests execution of a command on the FTP server
- * @method bool fget() fget(resource $handle, string $remote_file, int $mode, int $resumepos = 0) Downloads a file from the FTP server and saves to an open file
- * @method bool fput() fput(string $remote_file, resource $handle, int $mode, int $startpos = 0) Uploads from an open file to the FTP server
- * @method mixed get_option() get_option(int $option) Retrieves various runtime behaviours of the current FTP stream
- * @method bool get() get(string $local_file, string $remote_file, int $mode, int $resumepos = 0) Downloads a file from the FTP server
- * @method bool login() login(string $username, string $password) Logs in to an FTP connection
- * @method int mdtm() mdtm(string $remote_file) Returns the last modified time of the given file
- * @method string mkdir() mkdir(string $directory) Creates a directory
- * @method int nb_continue() nb_continue() Continues retrieving/sending a file (non-blocking)
- * @method int nb_fget() nb_fget(resource $handle, string $remote_file, int $mode, int $resumepos = 0) Retrieves a file from the FTP server and writes it to an open file (non-blocking)
- * @method int nb_fput() nb_fput(string $remote_file, resource $handle, int $mode, int $startpos = 0) Stores a file from an open file to the FTP server (non-blocking)
- * @method int nb_get() nb_get(string $local_file, string $remote_file, int $mode, int $resumepos = 0) Retrieves a file from the FTP server and writes it to a local file (non-blocking)
- * @method int nb_put() nb_put(string $remote_file, string $local_file, int $mode, int $startpos = 0) Stores a file on the FTP server (non-blocking)
- * @method array nlist() nlist(string $directory) Returns a list of files in the given directory
- * @method bool pasv() pasv(bool $pasv) Turns passive mode on or off
- * @method bool put() put(string $remote_file, string $local_file, int $mode, int $startpos = 0) Uploads a file to the FTP server
- * @method string pwd() pwd() Returns the current directory name
- * @method bool quit() quit() Closes an FTP connection
- * @method array raw() raw(string $command) Sends an arbitrary command to an FTP server
- * @method array rawlist() rawlist(string $directory, bool $recursive = false) Returns a detailed list of files in the given directory
- * @method bool rename() rename(string $oldname, string $newname) Renames a file or a directory on the FTP server
- * @method bool rmdir() rmdir(string $directory) Removes a directory
- * @method bool set_option() set_option(int $option, mixed $value) Set miscellaneous runtime FTP options
- * @method bool site() site(string $command) Sends a SITE command to the server
- * @method int size() size(string $remote_file) Returns the size of the given file
- * @method string systype() systype() Returns the system type identifier of the remote FTP server
+ * @method bool alloc(int $filesize, string &$result = null) Allocates space for a file to be uploaded
+ * @method bool cdup() Changes to the parent directory
+ * @method bool chdir(string $directory) Changes the current directory on a FTP server
+ * @method int chmod(int $mode, string $filename) Set permissions on a file via FTP
+ * @method bool close() Closes an FTP connection
+ * @method bool delete(string $path) Deletes a file on the FTP server
+ * @method bool exec(string $command) Requests execution of a command on the FTP server
+ * @method bool fget(resource $handle, string $remote_file, int $mode, int $resumepos = 0) Downloads a file from the FTP server and saves to an open file
+ * @method bool fput(string $remote_file, resource $handle, int $mode, int $startpos = 0) Uploads from an open file to the FTP server
+ * @method mixed get_option(int $option) Retrieves various runtime behaviours of the current FTP stream
+ * @method bool get(string $local_file, string $remote_file, int $mode, int $resumepos = 0) Downloads a file from the FTP server
+ * @method bool login(string $username, string $password) Logs in to an FTP connection
+ * @method int mdtm(string $remote_file) Returns the last modified time of the given file
+ * @method string mkdir(string $directory) Creates a directory
+ * @method int nb_continue() Continues retrieving/sending a file (non-blocking)
+ * @method int nb_fget(resource $handle, string $remote_file, int $mode, int $resumepos = 0) Retrieves a file from the FTP server and writes it to an open file (non-blocking)
+ * @method int nb_fput(string $remote_file, resource $handle, int $mode, int $startpos = 0) Stores a file from an open file to the FTP server (non-blocking)
+ * @method int nb_get(string $local_file, string $remote_file, int $mode, int $resumepos = 0) Retrieves a file from the FTP server and writes it to a local file (non-blocking)
+ * @method int nb_put(string $remote_file, string $local_file, int $mode, int $startpos = 0) Stores a file on the FTP server (non-blocking)
+ * @method array nlist(string $directory) Returns a list of files in the given directory
+ * @method bool pasv(bool $pasv) Turns passive mode on or off
+ * @method bool put(string $remote_file, string $local_file, int $mode, int $startpos = 0) Uploads a file to the FTP server
+ * @method string pwd() Returns the current directory name
+ * @method bool quit() Closes an FTP connection
+ * @method array raw(string $command) Sends an arbitrary command to an FTP server
+ * @method array rawlist(string $directory, bool $recursive = false) Returns a detailed list of files in the given directory
+ * @method bool rename(string $oldname, string $newname) Renames a file or a directory on the FTP server
+ * @method bool rmdir(string $directory) Removes a directory
+ * @method bool set_option(int $option, mixed $value) Set miscellaneous runtime FTP options
+ * @method bool site(string $command) Sends a SITE command to the server
+ * @method int size(string $remote_file) Returns the size of the given file
+ * @method string systype() Returns the system type identifier of the remote FTP server
  *
  * @author Nicolas Tallefourtane <dev@nicolab.net>
  */


### PR DESCRIPTION
Remove unnecessary repeating of function name in `@method` annotations. Static analysis tools as PHPStan are not able to handle this situation well.

Which is not compatible with PHPDoc:

> @method [[static] return type] [name]([[type] [parameter]<, ...>]) [<description>]

https://docs.phpdoc.org/references/phpdoc/tags/method.html