### PR TITLE
Added fallback logic to remove function

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -455,8 +455,16 @@ class FtpClient implements Countable
             if (@$this->ftp->delete($path)
             or ($this->isDir($path) and $this->rmdir($path, $recursive))) {
                 return true;
-            }
-
+            } else {
+                // in special cases the delete can fail (for example, at symfony's "r+e.gex[c]a(r)s" directory)
+                $newPath = preg_replace("/[^A-Za-z0-9\/]/", '', $path);
+                if ($this->rename($path, $newPath)) {
+                    if ($this->remove($newPath, $recursive)) {
+                        return true;
+                    }
+                }
+			}
+			
             return false;
         } catch (\Exception $e) {
             return false;


### PR DESCRIPTION
In some cases, the ftp_delete function can fail to delete a directory. In my case, I had to recursively delete directories that included the symfony folder named "r+e.gex[c]a(r)s". Due to the ftp_delete function failing on this directory, it was left out by the recursive deletion.

A workaround for this problem was renaming it to a valid directory name before attempting another delete.