### PR TITLE
fix invalid return type for mkdir (array -> bool)

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -355,7 +355,7 @@ class FtpClient implements Countable
      *
      * @param  string $directory The directory
      * @param  bool   $recursive
-     * @return array
+     * @return bool
      */
     public function mkdir($directory, $recursive = false)
     {

--- a/src/FtpClient/FtpWrapper.php
+++ b/src/FtpClient/FtpWrapper.php
@@ -27,7 +27,7 @@ namespace FtpClient;
  * @method bool get(string $local_file, string $remote_file, int $mode, int $resumepos = 0) Downloads a file from the FTP server
  * @method bool login(string $username, string $password) Logs in to an FTP connection
  * @method int mdtm(string $remote_file) Returns the last modified time of the given file
- * @method string mkdir(string $directory) Creates a directory
+ * @method bool mkdir(string $directory) Creates a directory
  * @method array mlsd(string $remote_dir) Returns a list of files in the given directory
  * @method int nb_continue() Continues retrieving/sending a file (non-blocking)
  * @method int nb_fget(resource $handle, string $remote_file, int $mode, int $resumepos = 0) Retrieves a file from the FTP server and writes it to an open file (non-blocking)


### PR DESCRIPTION
My PHPStorm was complaining about it.
As per [PHP documentation](https://www.php.net/manual/en/function.mkdir.php)

![image](https://user-images.githubusercontent.com/1164341/92712753-66787d00-f35a-11ea-9f34-3f69ba0cb1f4.png)