### PR TITLE
 warnings, consistency and type hinting

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -661,7 +661,7 @@ class FtpClient implements Countable
             }
         }
 
-		$d->close();
+        $d->close();
 
         return $this;
     }
@@ -695,7 +695,7 @@ class FtpClient implements Countable
         foreach ($contents as $file) { 
             if ($file === '.' || $file === '..') {
                 continue;
-	        }
+            }
 
             $this->ftp->get($target_directory."/".$file, $file, $mode);
         }

--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -301,18 +301,10 @@ class FtpClient implements Countable
         }
 
         // utils for recursion
-        $flatten = static function (array $arr) use (&$flatten) {
-            $flat = [];
-
-            foreach ($arr as $k => $v) {
-                if (is_array($v)) {
-                    $flat = array_merge($flat, $flatten($v));
-                } else {
-                    $flat[] = $v;
-                }
-            }
-
-            return $flat;
+        $flatten = static function (array $array) {
+	        $result = [];
+	        array_walk_recursive($array, static function($a) use (&$result) { $result[] = $a; });
+	        return $result;
         };
 
         foreach ($files as $file) {
@@ -765,7 +757,6 @@ class FtpClient implements Countable
                         $path .= ' '.$chunks[$i];
                     }
                 }
-
 
                 if (strpos($path, './') === 0) {
                     $path = substr($path, 2);

--- a/src/FtpClient/FtpWrapper.php
+++ b/src/FtpClient/FtpWrapper.php
@@ -77,7 +77,7 @@ class FtpWrapper
      * @return mixed
      * @throws FtpException When the function is not valid
      */
-    public function __call($function, array $arguments)
+    public function __call(string $function, array $arguments)
     {
         $function = 'ftp_' . $function;
 
@@ -97,7 +97,7 @@ class FtpWrapper
      * @param  int      $timeout
      * @return resource
      */
-    public function connect($host, $port = 21, $timeout = 90)
+    public function connect(string $host, int $port = 21, int $timeout = 90)
     {
         return @ftp_connect($host, $port, $timeout);
     }
@@ -109,7 +109,7 @@ class FtpWrapper
      * @param  int      $timeout
      * @return resource
      */
-    public function ssl_connect($host, $port = 21, $timeout = 90)
+    public function ssl_connect(string $host, int $port = 21, int $timeout = 90)
     {
         return @ftp_ssl_connect($host, $port, $timeout);
     }


### PR DESCRIPTION
Using PHP Inspections Enhanced plugin with PHPStorm to be extra precise for quality.
PHPStorm complains to me about the library while using it at work, so a few more adjustments to make that stop.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/1164341/92904919-89229880-f423-11ea-8b89-e7274523caae.png)  | ![image](https://user-images.githubusercontent.com/1164341/92904945-8e7fe300-f423-11ea-9a69-d7790d74bea9.png)  |

Remainder is a code duplication at `FtpClient.php:744` but I'd prefer not to refactor methods in dept as it poses no issue to me.

I noticed spaces used for indentation, which caused a wrong offset for me on 2 lines, which i reverted my change in the last commit.
I don't want to convert it all to tabs to make it work for `everyone` as I would touch literally everything.
I'll leave that up to you if you choose to :)