### PR TITLE
[Windows Compatibility] Support for Windows FTP listings

### DIFF
--- a/src/FtpClient/Objects/ListingRow.php
+++ b/src/FtpClient/Objects/ListingRow.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace FtpClient\Objects;
+
+class ListingRow {
+	public $permissions	= null;
+	public $number		= null;
+	public $owner		= null;
+	public $group		= null;
+	public $size		= null;
+	public $month		= null;
+	public $day			= null;
+	public $time		= null;
+	public $name		= null;
+	public $type		= null;
+	public $target		= null;
+}


### PR DESCRIPTION
I've just made PHP FTP Client compatible with Windows FTP systems. All of the keys remain the same when listing directories on PHP FTP Client, and I've normalized the values with the DateTime library.

In short, I've aimed to keep this PR fully backwards compatible with previous releases.