### PR TITLE
Add FTP file type constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,16 +75,16 @@ $total = $ftp->count();
 $total = $ftp->count('/path/of/directory');
 
 // count only the "files" in the current directory
-$total_file = $ftp->count('.', 'file');
+$total_file = $ftp->count('.', FtpClient::FILE_TYPE);
 
 // count only the "files" in a given directory
-$total_file = $ftp->count('/path/of/directory', 'file');
+$total_file = $ftp->count('/path/of/directory', FtpClient::FILE_TYPE);
 
 // count only the "directories" in a given directory
-$total_dir = $ftp->count('/path/of/directory', 'directory');
+$total_dir = $ftp->count('/path/of/directory', FtpClient::DIR_TYPE);
 
 // count only the "symbolic links" in a given directory
-$total_link = $ftp->count('/path/of/directory', 'link');
+$total_link = $ftp->count('/path/of/directory', FtpClient::LINK_TYPE);
 ```
 
 Detailed list of all files and directories :

--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -49,6 +49,15 @@ use \Countable;
 class FtpClient implements Countable
 {
     /**
+     * FTP file types.
+     */
+    const FILE_TYPE   = 'file';
+    const DIR_TYPE    = 'directory';
+    const LINK_TYPE   = 'link';
+    const UKNOWN_TYPE = 'unknown';
+    const ANY_TYPE    = null;
+
+    /**
      * The connection with the server.
      *
      * @var resource
@@ -541,7 +550,7 @@ class FtpClient implements Countable
      * @param  bool        $recursive true by default
      * @return int
      */
-    public function count($directory = '.', $type = null, $recursive = true)
+    public function count($directory = '.', $type = self::ANY_TYPE, $recursive = true)
     {
         $items  = (null === $type ? $this->nlist($directory, $recursive)
             : $this->scanDir($directory, $recursive));


### PR DESCRIPTION
Using type constants rather than passing string variables can make the code cleaner and easier to maintain.