### PR TITLE
Adding ReturnTypeWillChange attribute to silence PHP 8.1 deprecations

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -553,6 +553,7 @@ class FtpClient implements Countable
      * @param  bool        $recursive true by default
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count($directory = '.', $type = null, $recursive = true)
     {
         $items  = (null === $type ? $this->nlist($directory, $recursive)


### PR DESCRIPTION
`During inheritance of Countable: Uncaught ErrorException: Return type of FtpClient\FtpClient::count($directory = '.', $type = null, $recursive = true) should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/site/vendor/nicolab/php-ftp-client/src/FtpClient/FtpClient.php`

