### PR TITLE
Count must have a propper return type

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -575,7 +575,7 @@ class FtpClient implements Countable
      * @see countItems
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return $this->countItems();
     }


### PR DESCRIPTION
Using the version 2, we get now:
_Deprecated: Return type of FtpClient\FtpClient::count() should either be compatible with Countable::count(): int_

Interface is documented here https://www.php.net/manual/en/class.countable.php.