### PR TITLE
rmdir error

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -447,7 +447,8 @@ class FtpClient implements Countable
      */
     public function remove($path, $recursive = false)
     {
-        if ($path == '.' || $path == '..') {
+	$basename = basename($path);
+        if ($basename == '.' || $basename == '..') {
             return false;
         }
 


### PR DESCRIPTION
function remove was error in line 450.
$path was absolute path.