### PR TITLE
Fix raw file parsing

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -763,7 +763,7 @@ class FtpClient implements Countable
 
         if (false == $recursive) {
             foreach ($list as $path => $item) {
-                $chunks = preg_split("/\s+/", $item);
+                $chunks = preg_split("/\s+/", $item, 9);
 
                 // if not "name"
                 if (!isset($chunks[8]) || strlen($chunks[8]) === 0 || $chunks[8] == '.' || $chunks[8] == '..') {


### PR DESCRIPTION
At the moment, when encoutering folders or files with 2+ consecutive spaces in the filename, the function was splitting the file name. By limiting the split to 9 elements, this problem is fixed.