### PR TITLE
Fix for removing directory to prevent endless loop

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -447,7 +447,7 @@ class FtpClient implements Countable
      */
     public function remove($path, $recursive = false)
     {
-        if ($path == '.' || $path == '..') {
+        if (substr($path,-1) == '.' || substr($path,-2) == '..') {
             return false;
         }
 


### PR DESCRIPTION
When the directory to remove is foldername/.. or foldername/. then it will become in an endless loop and the code wil crash.