### PR TITLE
Fix PHP notation imcompatible with PHP 5.x versions

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -575,7 +575,7 @@ class FtpClient implements Countable
      * @see countItems
      * @return int
      */
-    public function count(): int
+    public function count()
     {
         return $this->countItems();
     }


### PR DESCRIPTION
Types declaration for return value in function are not supported in PHP 5.x versions. Remove the : int notation on the count() function