### PR TITLE
Add "Unable to list directory" exception in rawlist()

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -749,10 +749,14 @@ class FtpClient implements Countable
         if (strpos($directory, " ") > 0) {
             $ftproot = $this->ftp->pwd();
             $this->ftp->chdir($directory);
-            $list  = $this->ftp->rawlist("");
+            $list = $this->ftp->rawlist("");
             $this->ftp->chdir($ftproot);
         } else {
-            $list  = $this->ftp->rawlist($directory);
+            $list = $this->ftp->rawlist($directory);
+        }
+		
+        if ($list === false) {
+            throw new FtpException('Unable to list directory');
         }
 
         $items = array();


### PR DESCRIPTION
When ftp_rawlist() returns "false", it means an error occured.
It should be treated differently than a "[]" return.